### PR TITLE
Maintain formatting for Jinja delimiter characters

### DIFF
--- a/packages/formatter/src/core/Formatter.ts
+++ b/packages/formatter/src/core/Formatter.ts
@@ -78,6 +78,10 @@ export default class Formatter {
         formattedQuery = this.formatComma(token, formattedQuery);
       } else if (token.value === '.') {
         formattedQuery = this.formatWithoutSpaces(token, formattedQuery);
+      } else if (token.type === TokenTypes.OPEN_JINJA_DELIMITER) {
+        formattedQuery = this.formatWithSpaces(token, formattedQuery);      
+      } else if (token.type === TokenTypes.CLOSE_JINJA_DELIMITER) {
+          formattedQuery = this.formatWithSpaces(token, formattedQuery);
       } else if (token.value === ';' || token.type === TokenTypes.QUERY_SEPARATOR ) {
         formattedQuery = this.formatQuerySeparator(token, formattedQuery);
       } else {

--- a/packages/formatter/src/core/types.ts
+++ b/packages/formatter/src/core/types.ts
@@ -19,12 +19,16 @@ export enum TokenTypes {
   SERVERVARIABLE = 'servervariable',
   TABLENAME_PREFIX = 'tablename-prefix',
   TABLENAME = 'tablename',
+  OPEN_JINJA_DELIMITER = 'open-jinja-delimiter',
+  CLOSE_JINJA_DELIMITER = 'close-jinja-delimiter',
 }
+
 export interface Config {
   indent?: string;
   reservedWordCase?: string;
   params?: Object;
 }
+
 export interface TokenizerConfig {
   reservedWords: string[];
   reservedToplevelWords: string[];
@@ -36,6 +40,8 @@ export interface TokenizerConfig {
   indexedPlaceholderTypes?: string[];
   namedPlaceholderTypes: string[];
   lineCommentTypes: string[];
+  openJinjaDelimiters: string[];
+  closeJinjaDelimiters: string[];
 }
 
 export interface Token {

--- a/packages/formatter/src/languages/StandardSqlFormatter.ts
+++ b/packages/formatter/src/languages/StandardSqlFormatter.ts
@@ -38,6 +38,8 @@ function getTokenizer(): Tokenizer {
       namedPlaceholderTypes: ['@', ':', '%'],
       lineCommentTypes: ['#', '--'],
       tableNamePrefixWords,
+      openJinjaDelimiters: ['{{','{%','{#'],
+      closeJinjaDelimiters: ['}}','%}','#}'],
     });
   }
   return tokenizer;

--- a/packages/formatter/test/StandardSqlFormatter.test.ts
+++ b/packages/formatter/test/StandardSqlFormatter.test.ts
@@ -462,6 +462,20 @@ from a
 where
   id = $1`);
     });
+
+    it("Format query with Jinja delimiters", () => {
+        expect(sqlFormatter.format(`select * from {{ ref('a') }}`)).toEqual(
+`select
+  *
+from {{ ref('a') }}`);
+    });
+
+    it("Format query with Jinja delimiters with whitespace control characters", () => {
+        expect(sqlFormatter.format(`select {%- macro() -%} from a`)).toEqual(
+`select
+  {%- macro() -%}
+from a`);
+    });
 });
 
 // @TODO improve this tests


### PR DESCRIPTION
This PR preserves Jinja delimiters (`{{ ... }}, {% ... %}, {# ... #}`) used when writing code for dbt projects. 

Also preserves these delimiters in combination with `-` (used for [trimming whitespace](https://docs.getdbt.com/docs/writing-code-in-dbt/getting-started-with-jinja#reducing-whitespace).)

----

Thank you for your contribution! 
Before submitting this PR, please make sure:

- [x] Your code builds clean without any errors or warnings
- [x] You have made the needed changes to the docs
- [x] You have wrote a description of what is the purpose of this pull request above
